### PR TITLE
feat: add help center and improve dropdown menu

### DIFF
--- a/src/pods/landing/components/Header.tsx
+++ b/src/pods/landing/components/Header.tsx
@@ -17,9 +17,12 @@ export default function Header() {
           <Link to="/">
             Formats
           </Link>
-          <Link to="https://github.com/JunLovin/Routinary" target="_blank">
+          <a 
+            href="https://github.com/JunLovin/Routinary" 
+            target="_blank"
+          >
             GitHub
-          </Link>
+          </a>
           <Link to="/">
             FAQ
           </Link>

--- a/src/pods/main/Main.tsx
+++ b/src/pods/main/Main.tsx
@@ -6,7 +6,7 @@ export default function Main() {
   return (
     <>
       <section className="h-dvh flex items-center bg-zinc-900 overflow-hidden">
-        <div className="sidenav w-83">
+        <div className="sidenav">
           <Sidenav />
         </div>
         <div className="outlet h-full w-full p-4">

--- a/src/pods/main/chat/Chat.tsx
+++ b/src/pods/main/chat/Chat.tsx
@@ -1,11 +1,12 @@
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useState, useRef, useEffect, type KeyboardEvent } from 'react';
 import { Message as MessageComponent } from '@/shared/components/Message';
-import { SendHorizontal, Paperclip, Image as ImageIcon } from 'lucide-react';
+import { SendHorizontal, Paperclip, Image as ImageIcon, Mic } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useChatStore } from '@/shared/stores/chat.store';
 import { useRoutineStore } from '@/shared/stores/routine.store';
 import type { Message } from '@/shared/models/message.model';
+import MessageLoadingSpinner from '@/shared/components/MessageLoadingSpinner';
 
 export default function Chat() {
   const { userId, chatId } = useParams<{ userId: string; chatId?: string }>();
@@ -13,6 +14,7 @@ export default function Chat() {
   const navigate = useNavigate();
 
   const messages = useChatStore((state) => state.messages);
+  const isSending = useChatStore((state) => state.isSending);
 
   const addMessage = useChatStore((state) => state.addMessage);
   const removeMessage = useChatStore((state) => state.removeMessage);
@@ -89,6 +91,7 @@ export default function Chat() {
           token: token!,
         });
         actualRoutineId = routine.id;
+        navigate(`/main/${userId}/chat/${actualRoutineId}`);
       }
 
       await sendMessage(
@@ -98,7 +101,6 @@ export default function Chat() {
         token!,
         userId,
       );
-      navigate(`/main/${userId}/chat/${actualRoutineId}`);
     } catch (error) {
       console.error('Error sending message:', error);
       removeMessage(tempId);
@@ -113,6 +115,10 @@ export default function Chat() {
     }
   };
 
+  useEffect(() => {
+    setPrompt('');
+  }, [chatId]);
+
   return (
     <section className="h-full w-full flex flex-col items-center justify-between pb-8 pt-4">
       <div
@@ -121,19 +127,20 @@ export default function Chat() {
       >
         {messages.length > 0 ? (
           messages.map((m) => (
-            <MessageComponent key={m.id} sender={m.sender} content={m.content} createdAt={m.createdAt} />
+            <MessageComponent key={m.id} {...m} />
           ))
         ) : (
           <div className="h-[60dvh] flex items-center justify-center">
-            <h2 className="text-zinc-500 text-3xl font-medium text-center max-w-md">
+            <h2 className="text-zinc-500 text-4xl font-medium text-center w-xl">
               What routine are we architecting today?
             </h2>
           </div>
         )}
+        {isSending && <MessageLoadingSpinner />}
       </div>
 
       <div className="w-full max-w-4xl px-4 mt-4">
-        <div className="relative bg-zinc-900 rounded-3xl ring ring-zinc-800 p-2 focus-within:ring-1 focus-within:ring-zinc-700 transition-all">
+        <div className="relative bg-zinc-950 rounded-3xl ring ring-zinc-800 p-2 focus-within:ring-1 focus-within:ring-zinc-700 transition-all">
           <textarea
             ref={textareaRef}
             rows={1}
@@ -145,7 +152,7 @@ export default function Chat() {
           />
 
           <div className="absolute right-3 bottom-3 flex items-center gap-1">
-            <button 
+            <button
               aria-label="Attach Image"
               className="p-2 cursor-pointer text-zinc-400 hover:text-zinc-100 transition-colors"
             >
@@ -158,10 +165,16 @@ export default function Chat() {
               <Paperclip size={20} />
             </button>
             <button
+              aria-label="Send Audio"
+              className="p-2 cursor-pointer text-zinc-400 hover:text-zinc-100 transition-colors"
+            >
+              <Mic size={20} />
+            </button>
+            <button
               onClick={handleSendMessage}
               disabled={!prompt.trim()}
               className="ml-1 cursor-pointer p-2.5 bg-zinc-100 text-zinc-950 rounded-full disabled:bg-zinc-800 disabled:text-zinc-600 transition-all active:scale-95"
-              aria-label="Send Message"  
+              aria-label="Send Message"
             >
               <SendHorizontal size={18} strokeWidth={2.5} />
             </button>

--- a/src/pods/main/components/Sidenav.tsx
+++ b/src/pods/main/components/Sidenav.tsx
@@ -1,24 +1,28 @@
 import { useAuth } from '@/shared/hooks/useAuth';
 import { useRoutineStore } from '@/shared/stores/routine.store';
 import { toTitleCase } from '@/shared/utils/utils';
-import { ChevronUp, PanelRight, SquarePen, MessageSquare } from 'lucide-react';
+import { ChevronUp, PanelRight, SquarePen, MessageSquare, CircleQuestionMark } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { gsap } from 'gsap';
+import Dropdown from '@/shared/components/ui/dropdown/Dropdown';
 
 export default function Sidenav() {
   const { user, logout, token } = useAuth();
   const navigate = useNavigate();
-  const [isOpen, setIsOpen] = useState(true);
-
-  const sidenavRef = useRef<HTMLElement>(null);
-  const textContentRef = useRef<HTMLDivElement>(null);
+  const location = useLocation();
 
   const currentRoutine = useRoutineStore((state) => state.currentRoutine);
   const setCurrentRoutine = useRoutineStore((state) => state.setCurrentRoutine);
   const fetchRoutines = useRoutineStore((state) => state.fetchRoutines);
   const routines = useRoutineStore((state) => state.routines);
   const fetchRoutine = useRoutineStore((state) => state.fetchRoutine);
+
+  const [isOpen, setIsOpen] = useState(true);
+
+  const sidenavRef = useRef<HTMLElement>(null);
+  const textContentRef = useRef<HTMLDivElement>(null);
+  const pathname = location.pathname;
 
   useEffect(() => {
     if (!token) {
@@ -119,12 +123,21 @@ export default function Sidenav() {
 
         <button
           onClick={handleNewChat}
-          className={`w-full hover:bg-zinc-800 border border-zinc-700/50 rounded-lg p-2.5 cursor-pointer hover:text-orange-500 hover:border-orange-500/30 ${!currentRoutine ? 'bg-zinc-800 text-orange-500 border-orange-500/30' : ''} transition-all flex items-center ${isOpen ? 'justify-start' : 'justify-center'} gap-3`}
+          className={`w-full hover:bg-zinc-800 border border-zinc-700/50 rounded-lg p-2.5 cursor-pointer hover:text-orange-500 hover:border-orange-500/30 ${pathname.includes('new') ? 'bg-zinc-800 text-orange-500 border-orange-500/30' : ''} transition-all flex items-center ${isOpen ? 'justify-start' : 'justify-center'} gap-3`}
           title="New Chat"
         >
           <SquarePen size={20} className="shrink-0" />
           {isOpen && <span className="text-sm font-medium whitespace-nowrap">New Chat</span>}
         </button>
+
+        <Link
+          to={`/main/${user?.id}/help`}
+          className={`w-full hover:bg-zinc-800 border border-zinc-700/50 rounded-lg p-2.5 cursor-pointer ${pathname.includes('help') ? 'bg-zinc-800 text-orange-500 border-orange-500/30' : ''} hover:text-orange-500 hover:border-orange-500/30 transition-all flex items-center ${isOpen ? 'justify-start' : 'justify-center'} gap-3`}
+          title="Help Center"
+        >
+          <CircleQuestionMark size={20} className="shrink-0" />
+          {isOpen && <span className="text-sm font-medium whitespace-nowrap">Help Center</span>}
+        </Link>
       </div>
 
       <div className="flex-1 overflow-hidden flex flex-col">
@@ -134,7 +147,7 @@ export default function Sidenav() {
               Your Chats
             </span>
 
-            <div className="flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
+            <div className="flex-1 overflow-y-auto overflow-x-hidden max-h-190">
               <div className="flex flex-col gap-1.5">
                 {routines.length === 0 ? (
                   <div className="flex items-center justify-center py-8">
@@ -167,8 +180,14 @@ export default function Sidenav() {
         </div>
       </div>
 
-      <div className="p-3 border-t border-zinc-800">
-        <div className={`flex items-center gap-3 hover:bg-zinc-800 rounded-lg transition-all p-2 cursor-pointer group relative ${isOpen ? '' : 'justify-center'}`}>
+      <Dropdown
+        className="p-3 border-t border-zinc-800"
+        verticalPosition="above"
+        matchTriggerWidth
+      >
+        <Dropdown.Trigger
+          className={`flex items-center w-full gap-3 hover:bg-zinc-800 rounded-lg transition-all p-2 cursor-pointer group relative ${isOpen ? '' : 'justify-center'}`}
+        >
           <div className="relative shrink-0">
             <div
               className="size-10 select-none rounded-full bg-linear-to-br from-orange-500 to-orange-600 flex items-center justify-center text-white font-semibold text-sm"
@@ -178,6 +197,21 @@ export default function Sidenav() {
             </div>
             <div className="absolute bottom-0 right-0 size-3 bg-green-500 rounded-full border-2 border-zinc-950"></div>
           </div>
+
+          <Dropdown.Content>
+            <Dropdown.Item
+              onClick={() => logout(navigate)}
+            >
+              Logout
+            </Dropdown.Item>
+            <Dropdown.Item 
+              className="w-full"
+              as={Link}
+              to={`/main/${user?.id}/settings`}
+            >
+            Settings
+            </Dropdown.Item>
+          </Dropdown.Content>
 
           {isOpen && (
             <div ref={(el) => {
@@ -197,8 +231,8 @@ export default function Sidenav() {
           {isOpen && (
             <ChevronUp size={16} className="shrink-0 text-zinc-500 group-hover:text-zinc-300 transition-colors" />
           )}
-        </div>
-      </div>
+        </Dropdown.Trigger>
+      </Dropdown>
     </nav>
   );
 }

--- a/src/pods/main/components/Sidenav.tsx
+++ b/src/pods/main/components/Sidenav.tsx
@@ -198,21 +198,6 @@ export default function Sidenav() {
             <div className="absolute bottom-0 right-0 size-3 bg-green-500 rounded-full border-2 border-zinc-950"></div>
           </div>
 
-          <Dropdown.Content>
-            <Dropdown.Item
-              onClick={() => logout(navigate)}
-            >
-              Logout
-            </Dropdown.Item>
-            <Dropdown.Item 
-              className="w-full"
-              as={Link}
-              to={`/main/${user?.id}/settings`}
-            >
-            Settings
-            </Dropdown.Item>
-          </Dropdown.Content>
-
           {isOpen && (
             <div ref={(el) => {
               if (el && !isOpen) {
@@ -231,7 +216,22 @@ export default function Sidenav() {
           {isOpen && (
             <ChevronUp size={16} className="shrink-0 text-zinc-500 group-hover:text-zinc-300 transition-colors" />
           )}
+
         </Dropdown.Trigger>
+        <Dropdown.Content>
+          <Dropdown.Item
+            onClick={() => logout(navigate)}
+          >
+              Logout
+          </Dropdown.Item>
+          <Dropdown.Item
+            className="w-full"
+            as={Link}
+            to={`/main/${user?.id}/settings`}
+          >
+              Settings
+          </Dropdown.Item>
+        </Dropdown.Content>
       </Dropdown>
     </nav>
   );

--- a/src/pods/main/components/TopBar.tsx
+++ b/src/pods/main/components/TopBar.tsx
@@ -1,30 +1,43 @@
 import { useRoutineStore } from '@/shared/stores/routine.store';
-import { useLocation } from 'react-router-dom';
+import { Github } from 'lucide-react';
+import { useEffect } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 
 export default function TopBar() {
   const location = useLocation();
   const pathname = location.pathname.split('/');
   const breadcrum = pathname[pathname.length - 1];
 
-  const routines = useRoutineStore((state) => state.routines);
+  const currentRoutine = useRoutineStore((state) => state.currentRoutine);
 
   const generateTitle = () => {
     if (breadcrum === 'new') {
       return 'New Chat';
     }
 
-    const routine = routines.find((r) => r.id === breadcrum);
-    if (routine) {
-      return routine.title;
+    if (currentRoutine) {
+      return currentRoutine.title;
     }
 
     return '';
   };
 
+  useEffect(() => {
+    generateTitle();
+  }, [currentRoutine]);
+
   return (
     <>
-      <div className="top-bar w-full h-12 flex items-center justify-center">
+      <div className="top-bar w-full h-12 flex items-center justify-center relative">
         <h1 className="text-slate-100 font-semibold text-lg">{generateTitle()}</h1>
+        <Link
+          to="https://github.com/JunLovin/Routinary"
+          target="_blank"
+          className="absolute cursor-pointer right-3 top-1/2 -translate-y-1/2 text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+        >
+          <Github size={18} className="inline-block mr-1" />
+          View on GitHub
+        </Link>
       </div>
     </>
   );

--- a/src/pods/main/components/TopBar.tsx
+++ b/src/pods/main/components/TopBar.tsx
@@ -1,7 +1,6 @@
 import { useRoutineStore } from '@/shared/stores/routine.store';
 import { Github } from 'lucide-react';
-import { useEffect } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 export default function TopBar() {
   const location = useLocation();
@@ -22,22 +21,18 @@ export default function TopBar() {
     return '';
   };
 
-  useEffect(() => {
-    generateTitle();
-  }, [currentRoutine]);
-
   return (
     <>
       <div className="top-bar w-full h-12 flex items-center justify-center relative">
         <h1 className="text-slate-100 font-semibold text-lg">{generateTitle()}</h1>
-        <Link
-          to="https://github.com/JunLovin/Routinary"
+        <a
+          href="https://github.com/JunLovin/Routinary"
           target="_blank"
           className="absolute cursor-pointer right-3 top-1/2 -translate-y-1/2 text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
         >
           <Github size={18} className="inline-block mr-1" />
           View on GitHub
-        </Link>
+        </a>
       </div>
     </>
   );

--- a/src/pods/main/help/Help.tsx
+++ b/src/pods/main/help/Help.tsx
@@ -1,0 +1,34 @@
+export default function Help() {
+  return (
+    <>
+      <div className="h-dvh p-4 w-full text-zinc-100 overflow-y-auto">
+        <div className="h-full flex flex-col items-center justify-around text-center px-4">
+          <div className="top flex flex-col items-center justify-center gap-6">
+            <h1 className="font-semibold text-4xl text-center leading-normal">👋
+          Hey, Need Any Help?</h1>
+
+            <input
+              type="text"
+              placeholder="Search for help articles..."
+              className="w-md px-4 py-3 rounded-xl bg-zinc-950 border border-zinc-800 ring-zinc-800 focus:outline-none focus:ring-2 focus:ring-zinc-700 transition-all"
+            />
+          </div>
+          <div className="help-articles flex h-140 flex-col items-start justify-start gap-6 w-full">
+            <h2 className="text-2xl font-medium">Browse by Categories</h2>
+            <div className="categories grid grid-cols-3 gap-6 w-full">
+              {['Getting Started', 'Account Management', 'Troubleshooting', 'Best Practices'].map((category) => (
+                <button
+                  key={category}
+                  className="w-full text-left bg-zinc-900 border border-zinc-800 rounded-lg p-4 hover:bg-zinc-800 transition-colors"
+                >
+                  <h3 className="text-lg font-semibold">{category}</h3>
+                  <p className="text-sm text-zinc-500 mt-1">Find articles related to {category.toLowerCase()}.</p>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/pods/main/help/Help.tsx
+++ b/src/pods/main/help/Help.tsx
@@ -10,6 +10,7 @@ export default function Help() {
             <input
               type="text"
               placeholder="Search for help articles..."
+              aria-label="Search help articles"
               className="w-md px-4 py-3 rounded-xl bg-zinc-950 border border-zinc-800 ring-zinc-800 focus:outline-none focus:ring-2 focus:ring-zinc-700 transition-all"
             />
           </div>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -5,6 +5,7 @@ import Register from './pods/auth/register/Register';
 import Main from './pods/main/Main';
 import Landing from './pods/landing/Landing';
 import Chat from './pods/main/chat/Chat';
+import Help from './pods/main/help/Help';
 
 const routes = [
   {
@@ -32,6 +33,7 @@ const routes = [
         path: '/main/:userId',
         element: <Main />,
         children: [
+          { path: 'help', element: <Help /> },
           {
             path: 'chat',
             children: [

--- a/src/shared/components/Message.tsx
+++ b/src/shared/components/Message.tsx
@@ -1,21 +1,44 @@
-import { Check, Copy } from 'lucide-react';
-import { useState } from 'react';
+import { Calendar, Check, Copy, Download } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import type { Message } from '../models/message.model';
 import Markdown from 'react-markdown';
+import { useRoutineStore } from '../stores/routine.store';
+import { useAuth } from '../hooks/useAuth';
 
-export function Message(props: Partial<Message & { loading: boolean }>) {
+export function Message(props: Partial<Message>) {
+  const { token } = useAuth();
+
   const [isHover, setIsHover] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
 
+  const fetchRoutine = useRoutineStore((state) => state.fetchRoutine);
+
   const copyToClipboard = async () => {
-    if (props.loading) return;
     try {
-      await navigator.clipboard.writeText(props.content!).catch((err) => console.error(err));
+      if (!props.content) return;
+
+      await navigator.clipboard.writeText(props.content);
       setIsCopied(true);
 
       setTimeout(() => setIsCopied(false), 3000);
     } catch (error) {
-      console.error('Error copying to clipboard');
+      console.error('Error copying to clipboard:', error);
+      throw error;
+    }
+  };
+
+  const handleDownloadICS = () => {
+    if (!props.isICS || !props.content) return;
+
+    try {
+      const blob = new Blob([props.content], { type: 'text/calendar' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `routinary-calendar-${Date.now().toString()}.ics`;
+      link.click();
+    } catch (error) {
+      console.error('Error downloading the ICS file:', error);
       throw error;
     }
   };
@@ -30,7 +53,17 @@ export function Message(props: Partial<Message & { loading: boolean }>) {
     });
   };
 
-  const formattedText = props.content?.replace(/\\n/g, '\n');
+  const formattedText = useMemo(() => {
+    if (!props.content) return '';
+
+    return props.content.replace(/\\n/g, '\n');
+  }, [props.content]);
+
+  useEffect(() => {
+    if (props.isICS && props.routineId && token) {
+      fetchRoutine(props.routineId, token);
+    }
+  }, [fetchRoutine, token, props.isICS, props.routineId]);
 
   return (
     <>
@@ -49,7 +82,7 @@ export function Message(props: Partial<Message & { loading: boolean }>) {
           <div
             onMouseEnter={() => setIsHover(true)}
             onMouseLeave={() => setTimeout(() => setIsHover(false), 500)}
-            className="bg-zinc-950 justify-start h-auto w-max overflow-hidden max-w-md text-zinc-100 relative p-2 pb-12 flex rounded-xl items-center"
+            className={`bg-zinc-950 ${props.sender === 'AI' ? 'rounded-tl-none!' : 'rounded-tr-none!'} justify-start h-auto w-max overflow-x-auto max-w-md text-zinc-100 relative p-4 pb-12 flex rounded-2xl items-center`}
           >
             <span className="whitespace-pre-line w-full text-left"><Markdown>{formattedText}</Markdown></span>
             <div className="w-max absolute bottom-2 -right-4 -translate-x-1/2">
@@ -68,6 +101,42 @@ export function Message(props: Partial<Message & { loading: boolean }>) {
           )}
         </div>
       </div>
+
+      {props.isICS && (
+        <div className="flex flex-col gap-2 mt-2 group">
+          <div className="bg-zinc-900 border border-zinc-800 w-full max-w-xs p-3 rounded-xl rounded-tl-none shadow-lg">
+
+            <div className="flex items-center gap-3 mb-3">
+              <div className="bg-orange-500/10 p-2 rounded-lg">
+                <Calendar className="text-orange-500 w-5 h-5" />
+              </div>
+              <div className="flex flex-col overflow-hidden">
+                <span className="text-zinc-200 text-sm font-semibold truncate">
+            Calendar Event
+                </span>
+                <span className="text-zinc-500 text-xs uppercase tracking-wider">
+            .ics File
+                </span>
+              </div>
+            </div>
+
+            <button
+              onClick={handleDownloadICS}
+              className="w-full text-zinc-100 text-xs font-bold py-2.5 cursor-pointer
+                   bg-zinc-800 hover:bg-zinc-700 active:scale-[0.98]
+                   transition-all duration-200 rounded-lg flex items-center
+                   justify-center gap-2 uppercase tracking-tight shadow-inner"
+            >
+              <Download className="w-4 h-4" />
+       Download Event 
+            </button>
+          </div>
+
+          <span className="text-[10px] text-zinc-500 ml-1 italic">
+          Ready to import into Google or Apple Calendar
+          </span>
+        </div>
+      )}
     </>
   );
 }

--- a/src/shared/components/Message.tsx
+++ b/src/shared/components/Message.tsx
@@ -23,23 +23,28 @@ export function Message(props: Partial<Message>) {
       setTimeout(() => setIsCopied(false), 3000);
     } catch (error) {
       console.error('Error copying to clipboard:', error);
-      throw error;
     }
   };
 
   const handleDownloadICS = () => {
     if (!props.isICS || !props.content) return;
 
+    let url: string | null = null;
+
     try {
       const blob = new Blob([props.content], { type: 'text/calendar' });
-      const url = URL.createObjectURL(blob);
+      url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
       link.download = `routinary-calendar-${Date.now().toString()}.ics`;
       link.click();
+      link.remove();
     } catch (error) {
       console.error('Error downloading the ICS file:', error);
-      throw error;
+    } finally {
+      if (url) {
+        URL.revokeObjectURL(url);
+      }
     }
   };
 
@@ -82,7 +87,7 @@ export function Message(props: Partial<Message>) {
           <div
             onMouseEnter={() => setIsHover(true)}
             onMouseLeave={() => setTimeout(() => setIsHover(false), 500)}
-            className={`bg-zinc-950 ${props.sender === 'AI' ? 'rounded-tl-none!' : 'rounded-tr-none!'} justify-start h-auto w-max overflow-x-auto max-w-md text-zinc-100 relative p-4 pb-12 flex rounded-2xl items-center`}
+            className={`bg-zinc-950 ${props.sender === 'AI' ? '!rounded-tl-none' : '!rounded-tr-none'} justify-start h-auto w-max overflow-x-auto max-w-md text-zinc-100 relative p-4 pb-12 flex rounded-2xl items-center`}
           >
             <span className="whitespace-pre-line w-full text-left"><Markdown>{formattedText}</Markdown></span>
             <div className="w-max absolute bottom-2 -right-4 -translate-x-1/2">
@@ -112,10 +117,10 @@ export function Message(props: Partial<Message>) {
               </div>
               <div className="flex flex-col overflow-hidden">
                 <span className="text-zinc-200 text-sm font-semibold truncate">
-            Calendar Event
+                  Calendar Event
                 </span>
                 <span className="text-zinc-500 text-xs uppercase tracking-wider">
-            .ics File
+                  .ics File
                 </span>
               </div>
             </div>
@@ -128,7 +133,7 @@ export function Message(props: Partial<Message>) {
                    justify-center gap-2 uppercase tracking-tight shadow-inner"
             >
               <Download className="w-4 h-4" />
-       Download Event 
+                Download Event
             </button>
           </div>
 

--- a/src/shared/components/MessageLoadingSpinner.tsx
+++ b/src/shared/components/MessageLoadingSpinner.tsx
@@ -1,0 +1,29 @@
+const MessageLoadingSpinner = () => {
+  return (
+    <div className="flex items-center justify-center p-4">
+      <svg
+        className="animate-spin -ml-1 mr-3 h-5 w-5 text-orange-500"
+        xmlns="http://www.w3.org"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        ></circle>
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        ></path>
+      </svg>
+      <span className="text-gray-500">Loading message...</span>
+    </div>
+  );
+};
+
+export default MessageLoadingSpinner;

--- a/src/shared/components/ui/dropdown/Dropdown.tsx
+++ b/src/shared/components/ui/dropdown/Dropdown.tsx
@@ -1,0 +1,253 @@
+import { createContext, useCallback, useEffect, useRef, useState, type SetStateAction } from 'react';
+import Content from './content/Content';
+import Trigger from './trigger/Trigger';
+import Item from './item/Item';
+
+interface DropdownProps {
+  disabled?: boolean;
+  hoverMode?: boolean;
+  horizontalPosition?: 'auto' | 'left' | 'right';
+  verticalPosition?: 'auto' | 'above' | 'below';
+  matchTriggerWidth?: boolean;
+  preventScroll?: boolean;
+  initiallyOpened?: boolean;
+  className?: string;
+
+  onOpen?: () => void;
+  onClose?: () => void;
+  children:
+    | React.ReactNode
+    | ((renderProps: {
+      trigger: typeof Trigger;
+      content: typeof Content;
+      isOpen: boolean;
+      disabled?: boolean;
+    }) => React.ReactNode);
+}
+
+export interface DropdownContextType {
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<SetStateAction<boolean>>;
+  triggerRef: React.RefObject<HTMLElement | null>;
+  contentRef: React.RefObject<HTMLElement | null>;
+  contentStyles: React.CSSProperties;
+  hoverMode: boolean;
+
+  toggle: () => void;
+  open: () => void;
+  close: () => void;
+  closeLater: () => void;
+  disabled: boolean;
+}
+
+export const DropdownContext = createContext<DropdownContextType | null>(null);
+
+export default function Dropdown({
+  disabled = false,
+  hoverMode = false,
+  horizontalPosition = 'auto',
+  verticalPosition = 'auto',
+  matchTriggerWidth = false,
+  preventScroll = false,
+  initiallyOpened = false,
+  onOpen = () => {},
+  onClose = () => {},
+  className = '',
+  children,
+}: DropdownProps) {
+  const [isOpen, setIsOpen] = useState(initiallyOpened);
+  const [contentStyles, setContentStyles] = useState<React.CSSProperties>({});
+  
+  const triggerRef = useRef<HTMLElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const closeTimerRef = useRef<any>(null);
+
+  const calculatePosition = useCallback(() => {
+    if (!triggerRef.current || !contentRef.current) return;
+
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    const contentRect = contentRef.current.getBoundingClientRect();
+
+    const viewport = {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
+
+    let top: number | undefined;
+    let left: number | undefined;
+    let right: number | undefined;
+
+    if (verticalPosition === "above") {
+      top = triggerRect.top - contentRect.height;
+    } else if (verticalPosition === "below") {
+      top = triggerRect.bottom;
+    } else {
+      const spaceBelow = viewport.height - triggerRect.bottom;
+      const spaceAbove = triggerRect.top;
+
+      if (spaceBelow >= contentRect.height || spaceBelow >= spaceAbove) {
+        top = triggerRect.bottom;
+      } else {
+        top = triggerRect.top - contentRect.height;
+      }
+    }
+
+    if (horizontalPosition === "left") {
+      left = triggerRect.left;
+    } else if (horizontalPosition === "right") {
+      right = viewport.width - triggerRect.right;
+    } else {
+      const spaceRight = viewport.width - triggerRect.left;
+      const spaceLeft = triggerRect.right;
+
+      if (spaceRight >= contentRect.width || spaceRight >= spaceLeft) {
+        left = triggerRect.left;
+      } else {
+        right = viewport.width - triggerRect.right;
+      }
+    }
+
+    const newStyles: React.CSSProperties = { 
+      top, 
+      left, 
+      right,
+      ...(matchTriggerWidth ? { width: `${triggerRect.width}px` } : {})
+    };
+
+    setContentStyles(newStyles);
+  }, [horizontalPosition, verticalPosition, matchTriggerWidth]);
+
+  const open = useCallback(() => {
+    if (disabled) return;
+
+    if (hoverMode && closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+      return;
+    }
+
+    setIsOpen(true);
+  }, [disabled, hoverMode]);
+
+  const close = useCallback(() => {
+    if (disabled) return;
+    setIsOpen(false);
+  }, [disabled]);
+
+  const closeLater = useCallback(() => {
+    if (!hoverMode || disabled) return;
+
+    closeTimerRef.current = setTimeout(() => {
+      closeTimerRef.current = null;
+      close();
+    }, 200);
+  }, [hoverMode, disabled, close]);
+
+  const toggle = useCallback(() => {
+    if (disabled) return;
+    if (isOpen) {
+      close();
+    } else {
+      open();
+    }
+  }, [isOpen, disabled, close, open]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (event: any) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target) || contentRef.current?.contains(target)) {
+        return;
+      }
+      close();
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, close]);
+
+  useEffect(() => {
+    if (isOpen) {
+      onOpen?.();
+    } else {
+      onClose?.();
+    }
+  }, [isOpen, onOpen, onClose]);
+
+  // Prevent scroll when open
+  useEffect(() => {
+    if (!isOpen || !preventScroll) return;
+
+    const originalStyle = window.getComputedStyle(document.body).overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = originalStyle;
+    };
+  }, [isOpen, preventScroll]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    calculatePosition();
+
+    const handleResize = () => calculatePosition();
+    const handleScroll = () => calculatePosition();
+
+    window.addEventListener('resize', handleResize);
+    window.addEventListener('scroll', handleScroll, true);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      window.removeEventListener('scroll', handleScroll, true);
+    };
+  }, [isOpen, calculatePosition]);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) {
+        clearTimeout(closeTimerRef.current);
+      }
+    };
+  }, []);
+
+  const contextValue: DropdownContextType = {
+    isOpen,
+    setIsOpen,
+    close,
+    triggerRef,
+    contentRef,
+    contentStyles,
+    hoverMode,
+    toggle,
+    open,
+    closeLater,
+    disabled
+  };
+
+  const renderChildren = () => {
+    if (typeof children === "function") {
+      return children({
+        trigger: Trigger,
+        content: Content,
+        isOpen,
+        disabled,
+      });
+    }
+
+    return children;
+  };
+
+  return (
+    <DropdownContext.Provider value={contextValue}>
+      <div className={`relative inline-block ${className}`}>
+        {renderChildren()}
+      </div>
+    </DropdownContext.Provider>
+  );
+}
+
+Dropdown.Item = Item;
+Dropdown.Trigger = Trigger;
+Dropdown.Content = Content;

--- a/src/shared/components/ui/dropdown/content/Content.tsx
+++ b/src/shared/components/ui/dropdown/content/Content.tsx
@@ -1,0 +1,99 @@
+import { useContext, useEffect, useRef, type ReactNode } from 'react';
+import ReactDOM from 'react-dom';
+import { DropdownContext } from '../Dropdown';
+import { gsap } from 'gsap';
+
+interface DropdownContentProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function Content(props: DropdownContentProps) {
+  const context = useContext(DropdownContext);
+
+  if (!context) {
+    throw new Error('DropdownContent must be used within a Dropdown');
+  }
+
+  const {
+    contentRef,
+    contentStyles,
+    isOpen,
+    hoverMode,
+    open,
+    closeLater,
+  } = context;
+
+  const animationRef = useRef<gsap.core.Tween | null>(null);
+
+  useEffect(() => {
+    const element = contentRef.current;
+    if (!element) return;
+
+    if (animationRef.current) {
+      animationRef.current.kill();
+    }
+
+    if (isOpen) {
+      gsap.set(element, {
+        opacity: 0,
+        scale: 0.95,
+        y: -10,
+      });
+
+      animationRef.current = gsap.to(element, {
+        opacity: 1,
+        scale: 1,
+        y: 0,
+        duration: 0.2,
+        ease: 'power2.out',
+      });
+    } else {
+      animationRef.current = gsap.to(element, {
+        opacity: 0,
+        scale: 0.95,
+        y: -10,
+        duration: 0.15,
+        ease: 'power2.in',
+      });
+    }
+
+    return () => {
+      if (animationRef.current) {
+        animationRef.current.kill();
+      }
+    };
+  }, [isOpen, contentRef]);
+
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const interactionProps = hoverMode ? {
+    onMouseEnter: open,
+    onMouseLeave: closeLater,
+  } : {};
+
+  const content = (
+    <div
+      ref={contentRef as React.RefObject<HTMLDivElement | null>}
+      className="fixed z-50"
+      style={{
+        ...contentStyles,
+        transformOrigin: 'top center',
+      }}
+      {...interactionProps}
+      role="menu"
+    >
+      <div className={`bg-zinc-900 border border-zinc-800 rounded-xl shadow-2xl shadow-black/50 overflow-hidden ${props.className || ''}`}>
+        {props.children}
+      </div>
+    </div>
+  );
+
+  return ReactDOM.createPortal(content, document.body);
+}

--- a/src/shared/components/ui/dropdown/item/Item.tsx
+++ b/src/shared/components/ui/dropdown/item/Item.tsx
@@ -1,0 +1,73 @@
+import { useContext, useRef, type ReactNode } from 'react';
+import { DropdownContext } from '../Dropdown';
+import { gsap } from 'gsap';
+
+interface DropdownItemProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  children: ReactNode;
+  as?: React.ElementType;
+  disabled?: boolean;
+  to?: string;
+}
+
+export default function Item({
+  children,
+  as: Component = 'a',
+  disabled,
+  ...props
+}: DropdownItemProps) {
+  const context = useContext(DropdownContext);
+  const itemRef = useRef<HTMLElement>(null);
+
+  if (!context) {
+    throw new Error('DropdownItem must be used within a Dropdown');
+  }
+
+  const { close } = context;
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (disabled) {
+      e.preventDefault();
+      return;
+    }
+    props.onClick?.(e);
+    close();
+  };
+
+  const handleMouseEnter = () => {
+    if (!disabled && itemRef.current) {
+      gsap.to(itemRef.current, {
+        x: 4,
+        duration: 0.2,
+        ease: 'power2.out',
+      });
+    }
+  };
+
+  const handleMouseLeave = () => {
+    if (itemRef.current) {
+      gsap.to(itemRef.current, {
+        x: 0,
+        duration: 0.2,
+        ease: 'power2.out',
+      });
+    }
+  };
+
+  return (
+    <Component
+      ref={itemRef}
+      {...props}
+      className={`block px-4 py-2.5 text-sm transition-colors ${
+        disabled
+          ? 'text-zinc-600 cursor-not-allowed opacity-50'
+          : 'text-zinc-300 hover:text-white cursor-pointer'
+      } ${props.className || ''}`}
+      onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      aria-disabled={disabled}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/src/shared/components/ui/dropdown/trigger/Trigger.tsx
+++ b/src/shared/components/ui/dropdown/trigger/Trigger.tsx
@@ -1,0 +1,63 @@
+import { useContext, useRef } from 'react';
+import { DropdownContext, type DropdownContextType } from '../Dropdown';
+import { gsap } from 'gsap';
+
+interface DropdownTriggerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Trigger(props: DropdownTriggerProps) {
+  const context = useContext(DropdownContext) as DropdownContextType & { toggle: () => void; open: () => void; closeLater: () => void };
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  if (!context) {
+    throw new Error('DropdownTrigger must be used within a Dropdown');
+  }
+
+  const {
+    triggerRef,
+    toggle,
+    open,
+    closeLater,
+    hoverMode,
+    disabled,
+    isOpen,
+  } = context;
+
+  const handleClick = () => {
+    if (buttonRef.current && !hoverMode) {
+      gsap.to(buttonRef.current, {
+        scale: 0.95,
+        duration: 0.1,
+        yoyo: true,
+        repeat: 1,
+        ease: 'power2.inOut',
+      });
+    }
+    toggle();
+  };
+
+  const interactionProps = hoverMode ? {
+    onMouseEnter: open,
+    onMouseLeave: closeLater,
+  } : {
+    onClick: handleClick,
+  };
+
+  return (
+    <button
+      ref={(el) => {
+        buttonRef.current = el;
+        (triggerRef as React.RefObject<HTMLButtonElement | null>).current = el;
+      }}
+      className={`transition-colors cursor-pointer ${isOpen ? 'text-orange-500' : 'text-zinc-400 hover:text-zinc-100'} ${props.className || ''}`}
+      aria-haspopup="menu"
+      aria-expanded={isOpen}
+      {...interactionProps}
+      disabled={disabled}
+    >
+      {props.children}
+    </button>
+  );
+}

--- a/src/shared/models/message.model.ts
+++ b/src/shared/models/message.model.ts
@@ -5,4 +5,5 @@ export interface Message {
   userId?: string;
   content: string;
   createdAt: Date;
+  isICS?: boolean;
 };

--- a/src/shared/services/message.services.ts
+++ b/src/shared/services/message.services.ts
@@ -56,6 +56,7 @@ export const sendMessageService = async (data: CreateMessage): Promise<Message> 
     }
 
     const json = await response.json();
+
     return json;
   } catch (error) {
     console.error('Error sending message:', error);

--- a/src/shared/stores/chat.store.ts
+++ b/src/shared/stores/chat.store.ts
@@ -6,7 +6,9 @@ import type { Message } from '../models/message.model';
 type State = {
   currentRoutineId: string | null;
   messages: Message[];
+
   isLoading: boolean;
+  isSending: boolean;
   error: string | null;
 }
 
@@ -27,6 +29,7 @@ export const useChatStore = create<State & Actions>()(
     currentRoutineId: null,
     messages: [],
     isLoading: false,
+    isSending: false,
     error: null,
 
     addMessage: (message) => {
@@ -88,20 +91,27 @@ export const useChatStore = create<State & Actions>()(
         if (sender === 'USER' && !userId) {
           throw new Error('User ID is required to send a message');
         }
-        set((state: State) => { state.isLoading = true; state.error = null; });
+        set((state: State) => { state.isSending = true; state.error = null; });
 
-        const aiMessage = await sendMessageService({ routineId, sender, content, token, userId });
+        let aiMessage = await sendMessageService({ routineId, sender, content, token, userId });
+
+        if (aiMessage.content.includes('BEGIN:VCALENDAR')) {
+          aiMessage = {
+            ...aiMessage,
+            isICS: true,
+          };
+        }
 
         set((state: State) => {
           state.messages.push(aiMessage);
-          state.isLoading = false;
+          state.isSending = false;
         });
 
         return aiMessage;
       } catch (error) {
         const err = error instanceof Error ? error : new Error('Unknown error');
         console.error('Error sending message:', err);
-        set((state: State) => { state.error = err.message; state.isLoading = false; });
+        set((state: State) => { state.error = err.message; state.isSending = false; });
         throw error;
       }
     },

--- a/src/shared/stores/chat.store.ts
+++ b/src/shared/stores/chat.store.ts
@@ -95,7 +95,9 @@ export const useChatStore = create<State & Actions>()(
 
         let aiMessage = await sendMessageService({ routineId, sender, content, token, userId });
 
-        if (aiMessage.content.includes('BEGIN:VCALENDAR')) {
+        const icsRegex = /^[\s\S]*BEGIN:VCALENDAR[\s\S]*END:VCALENDAR[\s\S]*$/;
+
+        if (icsRegex.test(aiMessage.content)) {
           aiMessage = {
             ...aiMessage,
             isICS: true,

--- a/src/shared/stores/routine.store.ts
+++ b/src/shared/stores/routine.store.ts
@@ -92,9 +92,15 @@ export const useRoutineStore = create<State & Actions>()(
           throw new Error('Routine not found');
         }
 
+        const routineIndex = get().routines.findIndex((r) => r.id === routine.id);
+
         set((state: State) => {
           state.currentRoutine = routine;
           state.isLoading = false;
+
+          if (routineIndex !== -1) {
+            state.routines[routineIndex] = routine;
+          }
         });
 
         return routine;


### PR DESCRIPTION
This pull request introduces several UI and UX improvements across the main chat, navigation, and message components, and adds a new Help Center page. The changes focus on enhancing user interaction, accessibility, and overall usability of the application.

**Navigation and Layout Improvements:**

* Added a Help Center page (`Help.tsx`) and integrated it into the main navigation sidebar with a new "Help Center" button. The sidebar now also uses the current route for active state styling and includes a dropdown menu for user actions like logout and settings.
* The main layout (`Main.tsx`) removes the fixed width from the sidebar for better responsiveness.
* The top bar now displays the current routine title more reliably and adds a "View on GitHub" button linking to the repository. 

**Chat and Messaging Enhancements:**

* The chat input area now includes an audio message button (Mic icon) and a loading spinner when a message is being sent. The chat resets the prompt when the chat ID changes, and message rendering is simplified.
* The message component (`Message.tsx`) now supports displaying and downloading calendar event files (.ics), improves clipboard interaction, and adjusts message bubble styling for sender differentiation. 

**New Features:**

* Introduced a dedicated Help Center page with search and browse-by-category UI for user support. 
* Added a loading spinner component for message sending feedback. 

**Styling and Usability:**

* Improved focus and hover states, adjusted color schemes for better contrast, and refined component layouts for a more modern and accessible interface. 

**Routing and State Management:**

* Updated routing to include the Help Center and improved state management for current routine and chat navigation. 

These changes collectively provide a more robust, user-friendly, and feature-rich experience for users interacting with the chat and navigation interfaces.