### PR TITLE
feat: add initial message from the landing page to the chat

### DIFF
--- a/src/pods/auth/Auth.tsx
+++ b/src/pods/auth/Auth.tsx
@@ -1,5 +1,6 @@
 import Background from '@/assets/background.avif';
-import { Outlet } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { Link, Outlet } from 'react-router-dom';
 
 export default function Auth() {
   return (
@@ -11,6 +12,13 @@ export default function Auth() {
           style={{ backgroundImage: `url(${Background})` }}
           className="background h-full bg-fixed bg-contain bg-no-repeat max-lg:hidden"
         />
+        <Link
+          to="/"
+          className="absolute left-6 top-6 flex items-center gap-1 text-neutral-100 hover:text-white transition-colors font-medium"
+        >
+          <ArrowLeft size={24} />
+        Landing Page
+        </Link>
         <div className="outlet flex h-full flex-col justify-center items-center">
           <Outlet />
         </div>

--- a/src/pods/auth/login/Login.tsx
+++ b/src/pods/auth/login/Login.tsx
@@ -37,7 +37,7 @@ export default function Login() {
 
   return (
     <>
-      <section className="login min-h-screen flex items-center justify-center flex-col gap-6 bg-neutral-50/50">
+      <section className="login min-h-dvh flex items-center justify-center flex-col gap-6 bg-neutral-50/50">
         <div className="flex flex-col items-center gap-2">
           <h1 className="login-title text-4xl font-bold bg-linear-to-r from-orange-400 to-orange-600 bg-clip-text text-transparent leading-normal">
             Welcome Back

--- a/src/pods/landing/sections/Hero.tsx
+++ b/src/pods/landing/sections/Hero.tsx
@@ -1,8 +1,8 @@
 import Background from '@/assets/background.avif';
-import { ArrowRight, Mic, Plus, SendHorizonal, SlidersHorizontal } from 'lucide-react';
+import { ArrowRight, Mic, Plus, SendHorizontal, SlidersHorizontal } from 'lucide-react';
 import gsap from 'gsap';
 import { SplitText } from 'gsap/SplitText';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type KeyboardEvent } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/shared/hooks/useAuth';
 
@@ -61,10 +61,17 @@ export default function Hero() {
     const messageToSend = message.trim();
     setMessage('');
     if (isAuthenticated && user) {
-      navigate(`/main/${user.id}/chat/new?message=${encodeURIComponent(messageToSend)}`, { state: { initialMessage: messageToSend } });
+      navigate(`/main/${user.id}/chat/new`, { state: { initialMessage: messageToSend } });
       return;
     }
-    navigate('/auth/login');
+    navigate('/auth/login', { state: { initialMessage: messageToSend } });
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSendMessage();
+    }
   };
 
   return (
@@ -96,6 +103,7 @@ export default function Hero() {
               placeholder="Describe your ideal day... (e.g. Wake up at 6am, workout, deep work for 4 hours, and dinner at 8pm)"
               value={message}
               onChange={(e) => setMessage(e.target.value)}
+              onKeyDown={handleKeyDown}
             />
             <span className="flex-1"/>
             <div className="buttons w-full pb-2 h-full flex justify-between items-end text-white/80">
@@ -112,8 +120,9 @@ export default function Hero() {
                   className="real-time-ai disabled:bg-white/30 disabled:text-white/50 cursor-pointer bg-zinc-100 text-zinc-950 rounded-full p-1.5"
                   disabled={!message.trim()}
                   onClick={handleSendMessage}
+                  aria-label="Send message"
                 >
-                  <SendHorizonal size={24} />
+                  <SendHorizontal size={24} />
                 </button>
               </div>
             </div>

--- a/src/pods/landing/sections/Hero.tsx
+++ b/src/pods/landing/sections/Hero.tsx
@@ -1,16 +1,23 @@
 import Background from '@/assets/background.avif';
-import { ArrowRight, AudioLines, Mic, Plus, SlidersHorizontal } from 'lucide-react';
+import { ArrowRight, Mic, Plus, SendHorizonal, SlidersHorizontal } from 'lucide-react';
 import gsap from 'gsap';
 import { SplitText } from 'gsap/SplitText';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '@/shared/hooks/useAuth';
+
+const avatars = [
+  'https://i.pravatar.cc/150?img=59',
+  'https://i.pravatar.cc/150?img=53',
+  'https://i.pravatar.cc/150?img=57',
+  'https://i.pravatar.cc/150?img=64',
+];
 
 export default function Hero() {
-  const avatars = [
-    'https://i.pravatar.cc/150?img=59',
-    'https://i.pravatar.cc/150?img=53',
-    'https://i.pravatar.cc/150?img=57',
-    'https://i.pravatar.cc/150?img=64',
-  ];
+  const { isAuthenticated, user } = useAuth();
+  const navigate = useNavigate();
+
+  const [message, setMessage] = useState('');
 
   useEffect(() => {
     gsap.registerPlugin(SplitText);
@@ -48,6 +55,18 @@ export default function Hero() {
     };
   }, []);
 
+  const handleSendMessage = () => {
+    if (!message.trim()) return;
+
+    const messageToSend = message.trim();
+    setMessage('');
+    if (isAuthenticated && user) {
+      navigate(`/main/${user.id}/chat/new?message=${encodeURIComponent(messageToSend)}`, { state: { initialMessage: messageToSend } });
+      return;
+    }
+    navigate('/auth/login');
+  };
+
   return (
     <>
       <div
@@ -75,6 +94,8 @@ export default function Hero() {
             <textarea
               className="w-full resize-none min-h-14 overflow-y-auto outline-0 text-base"
               placeholder="Describe your ideal day... (e.g. Wake up at 6am, workout, deep work for 4 hours, and dinner at 8pm)"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
             />
             <span className="flex-1"/>
             <div className="buttons w-full pb-2 h-full flex justify-between items-end text-white/80">
@@ -87,19 +108,25 @@ export default function Hero() {
               </div>
               <div className="right-icons flex items-center gap-4">
                 <Mic />
-                <div className="real-time-ai bg-white/30 text-white/50 rounded-full p-1.5">
-                  <AudioLines size={24} />
-                </div>
+                <button
+                  className="real-time-ai disabled:bg-white/30 disabled:text-white/50 cursor-pointer bg-zinc-100 text-zinc-950 rounded-full p-1.5"
+                  disabled={!message.trim()}
+                  onClick={handleSendMessage}
+                >
+                  <SendHorizonal size={24} />
+                </button>
               </div>
             </div>
           </div>
           <div className="flex items-center justify-center gap-6 w-full relative">
-            <button className="rounded-lg text-lg h-12 relative font-medium pl-6 pr-1 cursor-pointer bg-linear-to-r from-orange-400 to-orange-600 text-white flex gap-4 items-center">
+            <Link
+              to="/auth/login"
+              className="rounded-lg text-lg h-12 relative font-medium pl-6 pr-1 cursor-pointer bg-linear-to-r from-orange-400 to-orange-600 text-white flex gap-4 items-center">
               Create Routine
               <div className="next-icon w-max h-max rounded-md bg-white p-1.5 text-orange-400">
                 <ArrowRight />
               </div>
-            </button>
+            </Link>
             <div className="group-avatars flex flex-row items-center relative max-lg:hidden">
               {avatars.map((avatar, i) => (
                 <div key={i} className="avatar size-12 -mr-4">

--- a/src/pods/main/chat/Chat.tsx
+++ b/src/pods/main/chat/Chat.tsx
@@ -38,7 +38,7 @@ export default function Chat() {
       hasSentInitialMessage.current = true;
       handleSendMessage(initialMessage);
     }
-  }, [location.state]);
+  }, [initialMessage]);
 
   useEffect(() => {
     const load = async () => {
@@ -77,7 +77,7 @@ export default function Chat() {
   }, [prompt]);
 
   const handleSendMessage = async (message?: string) => {
-    if (!prompt.trim()) return;
+    if (!(message || prompt).trim()) return;
 
     const tempId = `temp-${Date.now()}`;
     const messageContent = prompt;
@@ -182,7 +182,7 @@ export default function Chat() {
               <Mic size={20} />
             </button>
             <button
-              onClick={handleSendMessage}
+              onClick={() => handleSendMessage()}
               disabled={!prompt.trim()}
               className="ml-1 cursor-pointer p-2.5 bg-zinc-100 text-zinc-950 rounded-full disabled:bg-zinc-800 disabled:text-zinc-600 transition-all active:scale-95"
               aria-label="Send Message"

--- a/src/pods/main/chat/Chat.tsx
+++ b/src/pods/main/chat/Chat.tsx
@@ -2,7 +2,7 @@ import { useAuth } from '@/shared/hooks/useAuth';
 import { useState, useRef, useEffect, type KeyboardEvent } from 'react';
 import { Message as MessageComponent } from '@/shared/components/Message';
 import { SendHorizontal, Paperclip, Image as ImageIcon, Mic } from 'lucide-react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useChatStore } from '@/shared/stores/chat.store';
 import { useRoutineStore } from '@/shared/stores/routine.store';
 import type { Message } from '@/shared/models/message.model';
@@ -12,6 +12,9 @@ export default function Chat() {
   const { userId, chatId } = useParams<{ userId: string; chatId?: string }>();
   const { token } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const initialMessage = location.state?.initialMessage || '';
 
   const messages = useChatStore((state) => state.messages);
   const isSending = useChatStore((state) => state.isSending);
@@ -24,10 +27,18 @@ export default function Chat() {
 
   const createRoutine = useRoutineStore((state) => state.createRoutine);
 
-  const [prompt, setPrompt] = useState('');
+  const [prompt, setPrompt] = useState(initialMessage);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const hasSentInitialMessage = useRef(false);
+
+  useEffect(() => {
+    if (initialMessage && !hasSentInitialMessage.current) {
+      hasSentInitialMessage.current = true;
+      handleSendMessage(initialMessage);
+    }
+  }, [location.state]);
 
   useEffect(() => {
     const load = async () => {
@@ -65,7 +76,7 @@ export default function Chat() {
     }
   }, [prompt]);
 
-  const handleSendMessage = async () => {
+  const handleSendMessage = async (message?: string) => {
     if (!prompt.trim()) return;
 
     const tempId = `temp-${Date.now()}`;
@@ -74,7 +85,7 @@ export default function Chat() {
     const optimisticMessage: Message = {
       id: tempId,
       routineId: chatId || 'temp',
-      content: messageContent,
+      content: message ? message : messageContent,
       sender: 'USER',
       createdAt: new Date(),
     };
@@ -97,7 +108,7 @@ export default function Chat() {
       await sendMessage(
         actualRoutineId!,
         'USER',
-        messageContent,
+        message ? message : messageContent,
         token!,
         userId,
       );
@@ -131,7 +142,7 @@ export default function Chat() {
           ))
         ) : (
           <div className="h-[60dvh] flex items-center justify-center">
-            <h2 className="text-zinc-500 text-4xl font-medium text-center w-xl">
+            <h2 className="text-zinc-500 text-4xl font-medium text-center w-xl select-none">
               What routine are we architecting today?
             </h2>
           </div>

--- a/src/pods/main/components/Sidenav.tsx
+++ b/src/pods/main/components/Sidenav.tsx
@@ -224,12 +224,19 @@ export default function Sidenav() {
           >
               Logout
           </Dropdown.Item>
-          <Dropdown.Item
+         <Dropdown.Item
             className="w-full"
             as={Link}
             to={`/main/${user?.id}/settings`}
           >
               Settings
+          </Dropdown.Item>
+          <Dropdown.Item
+            className="w-full"
+            as={Link}
+            to="/"
+          >
+              Landing
           </Dropdown.Item>
         </Dropdown.Content>
       </Dropdown>


### PR DESCRIPTION
This pull request introduces several improvements to the authentication, landing, and chat flows of the application, focusing on enhancing user experience and navigation. The most significant changes include adding seamless navigation between the landing page and authentication/main app, enabling pre-filled and auto-sent chat messages from the landing page, and updating UI elements for better usability.

**Navigation & Routing Enhancements:**

* Added a "Back to Landing Page" link with an icon to the `Auth` layout, allowing users to easily return to the landing page from authentication screens (`Auth.tsx`).

**Landing Page to Chat Flow Improvements:**

* In the `Hero` section of the landing page, implemented logic to allow users to type a message and, upon clicking send, either navigate to a new chat (if authenticated) or redirect to the login page. The message is passed along and auto-sent in the chat if the user is authenticated (`Hero.tsx`). 

**Chat Initialization Enhancements:**

* Updated the chat component to accept an initial message via navigation state and automatically send it when the chat loads, enabling a smoother transition from the landing page to chat (`Chat.tsx`). 

**UI/UX Improvements:**

* Improved button accessibility and feedback in the landing page's `Hero` section, including disabling the send button when the message is empty and replacing a button with a `Link` for "Create Routine" to ensure correct navigation (`Hero.tsx`).
* Updated the login section's layout to use `min-h-dvh` for better viewport height handling (`Login.tsx`).
* Minor UI tweaks, such as making the empty chat prompt unselectable for better user experience (`Chat.tsx`).