### PR TITLE
feat: add settings pages

### DIFF
--- a/src/pods/main/Main.tsx
+++ b/src/pods/main/Main.tsx
@@ -51,7 +51,7 @@ export default function Main() {
         keywords: 'settings preferences configuration account',
         section: 'Navigation',
         perform: () => {
-          navigate(`/main/${user?.id}/settings`);
+          navigate(`/main/${user?.id}/settings/account`);
         },
       },
       {

--- a/src/pods/main/components/Sidenav.tsx
+++ b/src/pods/main/components/Sidenav.tsx
@@ -6,16 +6,19 @@ import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { gsap } from 'gsap';
 import Dropdown from '@/shared/components/ui/dropdown/Dropdown';
+import { useChatStore } from '@/shared/stores/chat.store';
 
 export default function Sidenav() {
   const { user, logout, token } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
 
+  const isSending = useChatStore((state) => state.isSending);
   const currentRoutine = useRoutineStore((state) => state.currentRoutine);
+  const routines = useRoutineStore((state) => state.routines);
+
   const setCurrentRoutine = useRoutineStore((state) => state.setCurrentRoutine);
   const fetchRoutines = useRoutineStore((state) => state.fetchRoutines);
-  const routines = useRoutineStore((state) => state.routines);
   const fetchRoutine = useRoutineStore((state) => state.fetchRoutine);
 
   const [isOpen, setIsOpen] = useState(true);
@@ -125,6 +128,7 @@ export default function Sidenav() {
           onClick={handleNewChat}
           className={`w-full hover:bg-zinc-800 border border-zinc-700/50 rounded-lg p-2.5 cursor-pointer hover:text-orange-500 hover:border-orange-500/30 ${pathname.includes('new') ? 'bg-zinc-800 text-orange-500 border-orange-500/30' : ''} transition-all flex items-center ${isOpen ? 'justify-start' : 'justify-center'} gap-3`}
           title="New Chat"
+          disabled={isSending}
         >
           <SquarePen size={20} className="shrink-0" />
           {isOpen && <span className="text-sm font-medium whitespace-nowrap">New Chat</span>}
@@ -134,6 +138,11 @@ export default function Sidenav() {
           to={`/main/${user?.id}/help`}
           className={`w-full hover:bg-zinc-800 border border-zinc-700/50 rounded-lg p-2.5 cursor-pointer ${pathname.includes('help') ? 'bg-zinc-800 text-orange-500 border-orange-500/30' : ''} hover:text-orange-500 hover:border-orange-500/30 transition-all flex items-center ${isOpen ? 'justify-start' : 'justify-center'} gap-3`}
           title="Help Center"
+          onClick={(e) => {
+            if (isSending) {
+              e.preventDefault();
+            }
+          }}
         >
           <CircleQuestionMark size={20} className="shrink-0" />
           {isOpen && <span className="text-sm font-medium whitespace-nowrap">Help Center</span>}
@@ -147,7 +156,7 @@ export default function Sidenav() {
               Your Chats
             </span>
 
-            <div className="flex-1 overflow-y-auto overflow-x-hidden max-h-190">
+            <div className="flex-1 overflow-y-auto overflow-x-hidden max-h-190 pb-2">
               <div className="flex flex-col gap-1.5">
                 {routines.length === 0 ? (
                   <div className="flex items-center justify-center py-8">
@@ -166,6 +175,7 @@ export default function Sidenav() {
                           : 'text-zinc-400'
                       }`}
                       title={!isOpen ? '' : routine.title}
+                      disabled={isSending}
                     >
                       <MessageSquare size={18} className="shrink-0" />
                       <span className="text-sm truncate flex-1">
@@ -184,6 +194,7 @@ export default function Sidenav() {
         className="p-3 border-t border-zinc-800"
         verticalPosition="above"
         matchTriggerWidth
+        disabled={isSending}
       >
         <Dropdown.Trigger
           className={`flex items-center w-full gap-3 hover:bg-zinc-800 rounded-lg transition-all p-2 cursor-pointer group relative ${isOpen ? '' : 'justify-center'}`}
@@ -220,13 +231,17 @@ export default function Sidenav() {
         </Dropdown.Trigger>
         <Dropdown.Content>
           <Dropdown.Item
-            onClick={() => logout(navigate)}
+            onClick={() => {
+              logout(navigate);
+              setCurrentRoutine(null);
+            }}
           >
               Logout
           </Dropdown.Item>
           <Dropdown.Item
             className="w-full"
             as={Link}
+            onClick={() => setCurrentRoutine(null)}
             to={`/main/${user?.id}/settings`}
           >
               Settings

--- a/src/pods/main/components/Sidenav.tsx
+++ b/src/pods/main/components/Sidenav.tsx
@@ -136,13 +136,15 @@ export default function Sidenav() {
 
         <Link
           to={`/main/${user?.id}/help`}
-          className={`w-full hover:bg-zinc-800 border border-zinc-700/50 rounded-lg p-2.5 cursor-pointer ${pathname.includes('help') ? 'bg-zinc-800 text-orange-500 border-orange-500/30' : ''} hover:text-orange-500 hover:border-orange-500/30 transition-all flex items-center ${isOpen ? 'justify-start' : 'justify-center'} gap-3`}
+          className={`w-full hover:bg-zinc-800 border border-zinc-700/50 rounded-lg p-2.5 cursor-pointer ${pathname.includes('help') ? 'bg-zinc-800 text-orange-500 border-orange-500/30' : ''} hover:text-orange-500 hover:border-orange-500/30 transition-all flex items-center ${isOpen ? 'justify-start' : 'justify-center'} gap-3 ${isSending ? 'pointer-events-none' : ''} `}
           title="Help Center"
           onClick={(e) => {
             if (isSending) {
               e.preventDefault();
             }
           }}
+          aria-disabled={isSending}
+          tabIndex={isSending ? -1 : 0}
         >
           <CircleQuestionMark size={20} className="shrink-0" />
           {isOpen && <span className="text-sm font-medium whitespace-nowrap">Help Center</span>}
@@ -169,11 +171,11 @@ export default function Sidenav() {
                     <button
                       key={routine.id}
                       onClick={() => goToRoutine(routine.id)}
-                      className={`w-full ${!isOpen ? 'cursor-default!' : ''} text-left hover:bg-zinc-800 rounded-lg p-2.5 cursor-pointer hover:text-orange-500 transition-all flex items-center gap-3 group ${
+                      className={`w-full ${!isOpen ? 'cursor-default!' : ''} select-none text-left hover:bg-zinc-800 rounded-lg p-2.5 cursor-pointer hover:text-orange-500 transition-all flex items-center gap-3 group ${
                         currentRoutine?.id === routine.id
                           ? 'bg-zinc-800 text-orange-500'
                           : 'text-zinc-400'
-                      }`}
+                      } ${isSending ? 'pointer-events-none' : ''}`}
                       title={!isOpen ? '' : routine.title}
                       disabled={isSending}
                     >
@@ -242,7 +244,7 @@ export default function Sidenav() {
             className="w-full"
             as={Link}
             onClick={() => setCurrentRoutine(null)}
-            to={`/main/${user?.id}/settings`}
+            to={`/main/${user?.id}/settings/account`}
           >
               Settings
           </Dropdown.Item>

--- a/src/pods/main/components/TopBar.tsx
+++ b/src/pods/main/components/TopBar.tsx
@@ -62,15 +62,25 @@ export default function TopBar() {
   }, []);
 
   const generateTitle = () => {
-    if (breadcrum === 'new') {
-      return 'New Chat';
+    switch (breadcrum) {
+      case 'new':
+        return 'New Chat';
+      case 'help':
+        return 'Help Center';
+      case 'settings':
+        return 'Settings';
+      case 'account':
+        return 'Account Settings';
+      case 'appearance':
+        return 'Appearance Settings';
+      case 'security':
+        return 'Security Settings';
+      default:
+        if (currentRoutine) {
+          return currentRoutine.title;
+        }
+        break;
     }
-
-    if (currentRoutine) {
-      return currentRoutine.title;
-    }
-
-    return '';
   };
 
   return (

--- a/src/pods/main/components/TopBar.tsx
+++ b/src/pods/main/components/TopBar.tsx
@@ -79,7 +79,7 @@ export default function TopBar() {
         if (currentRoutine) {
           return currentRoutine.title;
         }
-        break;
+        return '';
     }
   };
 

--- a/src/pods/main/settings/Settings.tsx
+++ b/src/pods/main/settings/Settings.tsx
@@ -1,0 +1,80 @@
+import { useAuth } from '@/shared/hooks/useAuth';
+import { PaletteIcon, Shield, User } from 'lucide-react';
+import { useEffect } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
+
+interface SettingOption {
+  label: string;
+  description?: string;
+  icon?: React.ReactNode;
+  action: () => void;
+  active: boolean;
+}
+
+export default function Settings() {
+  const { user } = useAuth();
+
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!user) {
+      navigate('/auth/login', { replace: true });
+    }
+  }, [user]);
+
+  const settingsOptions: SettingOption[] = [
+    {
+      label: 'Account',
+      description: 'Manage your account information and preferences.',
+      icon: <User />,
+      action: () => {
+        navigate(`/main/${user?.id}/settings/account`);
+      },
+      active: true,
+    },
+    {
+      label: 'Appareance',
+      description: 'Customize the look and feel of the application.',
+      icon: <PaletteIcon />,
+      action: () => {
+        navigate(`/main/${user?.id}/settings/appearance`);
+      },
+      active: true,
+    },
+    {
+      label: 'Security',
+      description: 'Manage your security settings and preferences.',
+      icon: <Shield />,
+      action: () => {
+        navigate(`/main/${user?.id}/settings/security`);
+      },
+      active: true,
+    },
+  ];
+
+  return (
+    <>
+      <div className="settings-container w-full h-[92dvh] flex text-zinc-400 rounded-xl">
+        <div className="settings-sidenav w-xs h-full flex flex-col gap-3 p-4 border border-zinc-800 rounded-xl bg-zinc-950">
+          {settingsOptions.map((o) => (
+            <div
+              key={o.label}
+              className="settings-option w-full hover:bg-zinc-800 rounded-lg p-2.5 gap-2 font-semibold cursor-pointer hover:text-orange-500 hover:border-orange-500/30 transition-all flex items-center"
+              onClick={() => {
+                o.action();
+              }}
+            >
+              <div className="settings-option-icon">{o.icon}</div>
+              <div className="settings-option-content">
+                <div className="settings-option-label">{o.label}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="flex-1 p-6">
+          <Outlet />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/pods/main/settings/Settings.tsx
+++ b/src/pods/main/settings/Settings.tsx
@@ -20,7 +20,7 @@ export default function Settings() {
     if (!user) {
       navigate('/auth/login', { replace: true });
     }
-  }, [user]);
+  }, [user, navigate]);
 
   const settingsOptions: SettingOption[] = [
     {
@@ -33,7 +33,7 @@ export default function Settings() {
       active: true,
     },
     {
-      label: 'Appareance',
+      label: 'Appearance',
       description: 'Customize the look and feel of the application.',
       icon: <PaletteIcon />,
       action: () => {
@@ -59,9 +59,16 @@ export default function Settings() {
           {settingsOptions.map((o) => (
             <div
               key={o.label}
+              role="button"
+              tabIndex={0}
               className="settings-option w-full hover:bg-zinc-800 rounded-lg p-2.5 gap-2 font-semibold cursor-pointer hover:text-orange-500 hover:border-orange-500/30 transition-all flex items-center"
               onClick={() => {
                 o.action();
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  o.action();
+                }
               }}
             >
               <div className="settings-option-icon">{o.icon}</div>

--- a/src/pods/main/settings/account/Account.tsx
+++ b/src/pods/main/settings/account/Account.tsx
@@ -1,0 +1,10 @@
+export default function Account() {
+  return (
+    <>
+      <div className="w-full h-full flex flex-col gap-4">
+        <h2 className="text-2xl font-bold text-zinc-100">Account Settings</h2>
+        <p className="text-zinc-400">Manage your account information and preferences.</p>
+      </div>
+    </>
+  );
+}

--- a/src/pods/main/settings/appearance/Appearance.tsx
+++ b/src/pods/main/settings/appearance/Appearance.tsx
@@ -1,0 +1,10 @@
+export default function Appearance() {
+  return (
+    <>
+      <div className="w-full h-full flex flex-col gap-4">
+        <h2 className="text-2xl font-bold text-zinc-100">Appearance Settings</h2>
+        <p className="text-zinc-400">Customize the look and feel of the application.</p>
+      </div>
+    </>
+  );
+}

--- a/src/pods/main/settings/security/Security.tsx
+++ b/src/pods/main/settings/security/Security.tsx
@@ -1,0 +1,10 @@
+export default function Security() {
+  return (
+    <>
+      <div className="w-full h-full flex flex-col gap-4">
+        <h2 className="text-2xl font-bold text-zinc-100">Security Settings</h2>
+        <p className="text-zinc-400">Manage your security settings and preferences.</p>
+      </div>
+    </>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -8,6 +8,10 @@ import Chat from './pods/main/chat/Chat';
 import Help from './pods/main/help/Help';
 import Categories from './pods/main/help/components/Categories';
 import Article from './pods/main/help/components/articles/Article';
+import Settings from './pods/main/settings/Settings';
+import Account from './pods/main/settings/account/Account';
+import Appearance from './pods/main/settings/appearance/Appearance';
+import Security from './pods/main/settings/security/Security';
 
 const routes = [
   {
@@ -58,6 +62,15 @@ const routes = [
             children: [
               { path: 'new', element: <Chat /> },
               { path: ':chatId', element: <Chat /> },
+            ],
+          },
+          {
+            path: 'settings',
+            element: <Settings />,
+            children: [
+              { path: 'account', element: <Account /> },
+              { path: 'appearance', element: <Appearance /> },
+              { path: 'security', element: <Security /> },
             ],
           },
         ],

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -12,6 +12,7 @@ import Settings from './pods/main/settings/Settings';
 import Account from './pods/main/settings/account/Account';
 import Appearance from './pods/main/settings/appearance/Appearance';
 import Security from './pods/main/settings/security/Security';
+import { Navigate } from 'react-router-dom';
 
 const routes = [
   {
@@ -68,6 +69,7 @@ const routes = [
             path: 'settings',
             element: <Settings />,
             children: [
+              { index: true, element: <Navigate to="account" replace /> },
               { path: 'account', element: <Account /> },
               { path: 'appearance', element: <Appearance /> },
               { path: 'security', element: <Security /> },

--- a/src/shared/components/Message.tsx
+++ b/src/shared/components/Message.tsx
@@ -87,11 +87,11 @@ export function Message(props: Partial<Message>) {
           <div
             onMouseEnter={() => setIsHover(true)}
             onMouseLeave={() => setTimeout(() => setIsHover(false), 500)}
-            className={`bg-zinc-950 ${props.sender === 'AI' ? '!rounded-tl-none !w-xl' : '!rounded-tr-none w-max max-w-md'} justify-start h-auto overflow-x-auto text-zinc-100 relative p-4 pb-12 flex rounded-2xl items-center`}
+            className={`bg-zinc-950 ${props.sender === 'AI' ? '!rounded-tl-none !w-xl' : '!rounded-tr-none w-max max-w-md'} justify-start h-auto overflow-x-auto text-zinc-100 relative p-4 pb-12 flex rounded-2xl items-center min-w-[80px]`}
           >
             <span className="whitespace-pre-line w-full text-left"><Markdown>{formattedText}</Markdown></span>
-            <div className="w-max absolute bottom-2 -right-4 -translate-x-1/2">
-              <span className="text-zinc-600">{formatDate(props.createdAt)}</span>
+            <div className="w-max absolute bottom-2 right-0 -translate-x-1/2">
+              <span className="text-zinc-600 text-sm font-medium">{formatDate(props.createdAt)}</span>
             </div>
           </div>
 


### PR DESCRIPTION
This pull request introduces several improvements to the sidebar navigation and settings experience, as well as enhancements to chat UI and routing. The most significant changes are the addition of a dedicated settings section with modular pages, improved navigation controls during chat operations, and UI refinements for message display.

**Settings and Navigation Enhancements**

* Added a new modular settings section with dedicated pages for Account, Appearance, and Security, including sidebar navigation and routing setup. 
* Updated the top bar title generation logic to support new settings and help pages, improving user context awareness. 

**Sidebar Controls During Chat Sending**

* Disabled navigation buttons (New Chat, Help Center, routine selection, dropdown) in the sidebar when a chat is being sent, preventing accidental navigation and improving UX. 
* Prevented navigation to Help Center when a chat is sending, using an onClick handler to block the action. 

**Routine State Management**

* Improved routine state handling by clearing the current routine on logout and when navigating to settings, ensuring a clean state. 

**UI Improvements**

* Refined message display with minimum width, improved timestamp styling, and better layout for chat messages. 
* Added padding to the chat list container for improved scroll experience. 